### PR TITLE
Reduce height of custom buttons in menu bar

### DIFF
--- a/src/chrome/global/toolbarbutton.css
+++ b/src/chrome/global/toolbarbutton.css
@@ -128,3 +128,10 @@ toolbarbutton[type="menu-button"][disabled="true"]:hover:active {
 .toolbarbutton-menubutton-dropmarker[disabled="true"] {
   padding: 3px !important;
 }
+
+/* Make sure that toolbar buttons placed in the menu bar do not make it take up too much space. */
+
+#toolbar-menubar toolbarbutton {
+	padding-top: 1px !important;
+	padding-bottom: 1px !important;
+}


### PR DESCRIPTION
I like to put the Fire IE toggle button in the menu bar. This fix is one way to prevent the issue where it takes up too much vertical space and makes the menu bar larger.